### PR TITLE
Adopted .travis.xml from image-builder-rpi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ branches:
 deploy:
   provider: releases
   skip_cleanup: true
-  api_key:
-    secure: H6eGuM+fgJEzlrV1N5KpKVZ6yiGVJPSjy5V7lYCO0cUFJ0bZuvHAoxg3es3+oNVJ7x4opd5oWhPTruZHuYX1B8cADETiNxd9IFIYlMFS0QFZwbhvbvk6kLTUI7XUjc42xBmNrO4ipSgLp+fERrbXk2qO8Cj3pOWsZYPC5bhG5ZAOt6+wSJ4wsDpPgENkDLUpigMZ+2J4EzoEDNKwnURJ4YmVOtGMfEafqh72lWdk1E6tRoZ03TLmYx9/ycbwcbhd1LCXUIUR7ZXPf/YmQuNhExgSBo2/hFs9uyZ+LNXzTWuh+9DC7ddqZ6l/SkkVFr4qTDHVgvz6KxGjhr1ueWzR+7JJkskFpS4cr1r41jF30WCC+VxKSVsw7KQo/qwGT4hwEPMyseJNggyilntZRSAMZDiUDoEEbmcR6gjgIqwqfv8mHQqURrQYKPktTTDmqxN4DvNHuKTsyFIsVX0Z8t7j/351T7eiiq6+kzrqbNB6G9HzpSHhl92xjt2KxDK33wFg/JqFlKFrQY2NdHIKEFmm1TZD5RcHeKwoxMS7V0/dFzVv77PWPphQfbo846sHvZRNWCy/mneJzAk9wvACMW4MkdGJhHgdxOjnve9aTYM7/hXHwCs8eOGOu+3m46PzKZbIhcq/kcLew7xL/5j0GU+wF/YuvtIIXeTzUjPFMloLWKo=
+  api_key: ${GITHUB_TOKEN}
   file:
     - hypriotos-odroid-c2-${TRAVIS_TAG}.img.zip
     - hypriotos-odroid-c2-${TRAVIS_TAG}.img.zip.sha256

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ branches:
     - /^v\d.*$/
 deploy:
   provider: releases
+  skip_cleanup: true
   api_key:
-    secure: nr2rOyatwZuzn+FNugjNVEAnG301TqGPsM7CorBMNKH72ND95w/Rf/ruyW/tljoDf4MOEJ+cuyyyONVG+bgxxAkY8dwbtDmrl0W6EjERkvhUqls1WUDLc1r+d3A+OHxpkmXtN5LxPjGaTpt4hYWjv4SEb18yYlmJaE5Nh83IImtVjVA1q2SUzfSe3cYaPKPG522lYO7owB+DWrdA98X8Sd0bdYoMVd1hLWBzicGcK1boA/7u7+RSl/yIZjbLillXYXFiyaU48hYyfIGjbh7/FYw0ofaqsGxn6BLV9EkyQfuyISwAEu5jMKbNRBBrbknVJWGfqW037Ss8lXyaXaFQ3omc43rpb8H90tfv75qn+WBi6Zn0cS/iMCpchkbN7Vx7HbYaqyYnkbK6Yd2yE6Z8pWQXvd9W+2MjZiGT/PKELMLDTUQ/bRpR7erIXuNbgvxpi1MHhHppIpnyRj6NewV8JWlsJ3PJOlkOqMYVezweTL3VzE/0yq5g/IQ0O1LRHIUVMQ9coW6y2/dddQhFy90Ayk8MvI//76jRAs/Vu22dPWWIuYoFTmZXMCAIwXmPBYKrlzk2T+l8F1Ma+jwDw0kCDHq3E5sYfY8vfnLIZRRC1MGnbruPLZJpI8jL075I1kQR954gVmFqGbziDpR0kJZzrInEj01iniEWuyQOljh2msE=
+    secure: H6eGuM+fgJEzlrV1N5KpKVZ6yiGVJPSjy5V7lYCO0cUFJ0bZuvHAoxg3es3+oNVJ7x4opd5oWhPTruZHuYX1B8cADETiNxd9IFIYlMFS0QFZwbhvbvk6kLTUI7XUjc42xBmNrO4ipSgLp+fERrbXk2qO8Cj3pOWsZYPC5bhG5ZAOt6+wSJ4wsDpPgENkDLUpigMZ+2J4EzoEDNKwnURJ4YmVOtGMfEafqh72lWdk1E6tRoZ03TLmYx9/ycbwcbhd1LCXUIUR7ZXPf/YmQuNhExgSBo2/hFs9uyZ+LNXzTWuh+9DC7ddqZ6l/SkkVFr4qTDHVgvz6KxGjhr1ueWzR+7JJkskFpS4cr1r41jF30WCC+VxKSVsw7KQo/qwGT4hwEPMyseJNggyilntZRSAMZDiUDoEEbmcR6gjgIqwqfv8mHQqURrQYKPktTTDmqxN4DvNHuKTsyFIsVX0Z8t7j/351T7eiiq6+kzrqbNB6G9HzpSHhl92xjt2KxDK33wFg/JqFlKFrQY2NdHIKEFmm1TZD5RcHeKwoxMS7V0/dFzVv77PWPphQfbo846sHvZRNWCy/mneJzAk9wvACMW4MkdGJhHgdxOjnve9aTYM7/hXHwCs8eOGOu+3m46PzKZbIhcq/kcLew7xL/5j0GU+wF/YuvtIIXeTzUjPFMloLWKo=
   file:
     - hypriotos-odroid-c2-${TRAVIS_TAG}.img.zip
+    - hypriotos-odroid-c2-${TRAVIS_TAG}.img.zip.sha256
   on:
     tags: true
     repo: hypriot/image-builder-odroid-c2


### PR DESCRIPTION
Not sure if this is the right thing to do, but this PR picks up two things from ```.travis.yml``` as present in ```image-builder-rpi```:

- ```skip-cleanup: true```- this is definitely important according to Travis CI doc.
- ``api_key`` - not sure if the same value as in ```image-builder-rpi```will work here.