### PR TITLE
Fixed minor problems with integration tests

### DIFF
--- a/builder/test-integration/spec/hypriotos-image/base/kernel_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/kernel_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe command('uname -r') do
-  its(:stdout) { should match /3.14.79(-v7)?+/ }
+  its(:stdout) { should match /3.14.79?+/ }
   its(:exit_status) { should eq 0 }
 end
 
-describe file('/lib/modules/3.14.79-107/kernel') do
+describe file('/lib/modules/3.14.79-108/kernel') do
   it { should be_directory }
 end

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -65,7 +65,7 @@ describe file('/var/lib/docker') do
   it { should be_owned_by 'root' }
 end
 
-describe file('/var/lib/docker/overlay') do
+describe file('/var/lib/docker/aufs') do
   it { should be_directory }
   it { should be_mode 700 }
   it { should be_owned_by 'root' }
@@ -90,7 +90,7 @@ describe command('docker version') do
 end
 
 describe command('docker info') do
-  its(:stdout) { should match /Storage Driver: overlay/ }
+  its(:stdout) { should match /Storage Driver: aufs/ }
   its(:exit_status) { should eq 0 }
 end
 


### PR DESCRIPTION
Although release ```0.2.2``` should work perfectly fine, there are minor issues running integration-tests:

- Kernel build in the image (```108```) does not match the one in the test (```107```)
- In PR #16 I made a late change to switch back from ```overlay``` to ```aufs```, because I could not successfully build docker on the Odroid C2 (```make deb```). Unfortunately, I forgot to fix the tests as well.