### PR TITLE
Added support for seccomp

### DIFF
--- a/builder/build.sh
+++ b/builder/build.sh
@@ -123,7 +123,7 @@ _EOF_
 umask 0000
 
 # compress image
-zip "${BUILD_RESULT_PATH}/${HYPRIOT_IMAGE_NAME}.zip" "${HYPRIOT_IMAGE_NAME}"
+pigz --zip -c "${BUILD_RESULT_PATH}/$HYPRIOT_IMAGE_NAME" > "$HYPRIOT_IMAGE_NAME.zip"
 cd ${BUILD_RESULT_PATH} && sha256sum "${HYPRIOT_IMAGE_NAME}.zip" > "${HYPRIOT_IMAGE_NAME}.zip.sha256" && cd -
 
 # test sd-image that we have built

--- a/builder/build.sh
+++ b/builder/build.sh
@@ -123,7 +123,7 @@ _EOF_
 umask 0000
 
 # compress image
-pigz --zip -c "${BUILD_RESULT_PATH}/$HYPRIOT_IMAGE_NAME" > "$HYPRIOT_IMAGE_NAME.zip"
+pigz --zip -c "${HYPRIOT_IMAGE_NAME}" > "${BUILD_RESULT_PATH}/${HYPRIOT_IMAGE_NAME}.zip"
 cd ${BUILD_RESULT_PATH} && sha256sum "${HYPRIOT_IMAGE_NAME}.zip" > "${HYPRIOT_IMAGE_NAME}.zip.sha256" && cd -
 
 # test sd-image that we have built

--- a/builder/chroot-script.sh
+++ b/builder/chroot-script.sh
@@ -99,6 +99,9 @@ export DEST
 mkdir -p "$(dirname "${DEST}")"
 echo "nameserver 8.8.8.8" > "${DEST}"
 
+# set up debian jessie backports
+echo "deb http://httpredir.debian.org/debian jessie-backports main" > /etc/apt/sources.list.d/jessie-backports.list
+
 # set up ODROID repository
 ODROID_KEY_ID=AB19BAC9
 get_gpg $ODROID_KEY_ID
@@ -134,6 +137,7 @@ packages=(
     cgroupfs-mount
     cgroup-bin
     apparmor
+    libseccomp2
     libltdl7
 
     # install docker-compose, and docker-machine
@@ -146,7 +150,9 @@ packages=(
 apt-get -y install ${packages[*]}
 
 # install linux kernel for Odroid C2
-apt-get -y install u-boot-tools linux-image-c2
+apt-get -y install \
+    u-boot-tools \
+    linux-image-c2="${KERNEL_VERSION}"
 
 # install docker-engine
 DOCKER_DEB=$(mktemp)

--- a/builder/files/etc/modprobe.d/blacklist-spi.conf
+++ b/builder/files/etc/modprobe.d/blacklist-spi.conf
@@ -1,0 +1,3 @@
+blacklist spidev
+blacklist spi_gpio
+blacklist spi_bitbang

--- a/builder/files/etc/udev/rules.d/10-odroid.rules
+++ b/builder/files/etc/udev/rules.d/10-odroid.rules
@@ -1,0 +1,19 @@
+# Mali Rules
+KERNEL=="mali",SUBSYSTEM=="misc",MODE="0777"
+KERNEL=="ump",SUBSYSTEM=="ump",MODE="0777"
+
+# Misc video rules
+KERNEL=="event*", SUBSYSTEM=="input", MODE="0777"
+KERNEL=="CEC", MODE="0777"
+KERNEL=="am*", MODE="0666"
+
+# Automatic Disk Scheduler
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0",ATTR{queue/scheduler}="noop"
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="1",ATTR{queue/scheduler}="deadline"
+ACTION=="add|change", KERNEL=="mmcblk[0-9]", ATTR{queue/rotational}=="0",ATTR{queue/scheduler}="noop"
+
+# GPIO Mem
+SUBSYSTEM=="meson-gpiomem", GROUP="sys", MODE="0660"
+
+# CEC Compat
+KERNEL=="cec", SYMLINK+="aocec"

--- a/builder/test-integration/spec/hypriotos-image/base/kernel_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/base/kernel_spec.rb
@@ -5,6 +5,6 @@ describe command('uname -r') do
   its(:exit_status) { should eq 0 }
 end
 
-describe file('/lib/modules/3.14.79-107/kernel') do
+describe file('/lib/modules/3.14.79-108/kernel') do
   it { should be_directory }
 end

--- a/builder/test-integration/spec/hypriotos-image/docker_spec.rb
+++ b/builder/test-integration/spec/hypriotos-image/docker_spec.rb
@@ -6,7 +6,7 @@ end
 
 describe command('dpkg -l docker-engine') do
   its(:stdout) { should match /ii  docker-engine/ }
-  its(:stdout) { should match /1.13.1-0~debian-jessie/ }
+  its(:stdout) { should match /17.03.0~ce-0~debian-jessie/ }
   its(:exit_status) { should eq 0 }
 end
 
@@ -65,7 +65,7 @@ describe file('/var/lib/docker') do
   it { should be_owned_by 'root' }
 end
 
-describe file('/var/lib/docker/overlay') do
+describe file('/var/lib/docker/aufs') do
   it { should be_directory }
   it { should be_mode 700 }
   it { should be_owned_by 'root' }
@@ -79,18 +79,18 @@ describe file('/etc/bash_completion.d/docker') do
 end
 
 describe command('docker -v') do
-  its(:stdout) { should match /Docker version 1.13.1, build/ }
+  its(:stdout) { should match /Docker version 17.03.0-ce, build/ }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker version') do
-  its(:stdout) { should match /Client:. Version:      1.13.1. API version:  1.26/m }
-  its(:stdout) { should match /Server:. Version:      1.13.1. API version:  1.26/m }
+  its(:stdout) { should match /Client:. Version:      17.03.0-ce. API version:  1.26/m }
+  its(:stdout) { should match /Server:. Version:      17.03.0-ce. API version:  1.26/m }
   its(:exit_status) { should eq 0 }
 end
 
 describe command('docker info') do
-  its(:stdout) { should match /Storage Driver: overlay/ }
+  its(:stdout) { should match /Storage Driver: aufs/ }
   its(:exit_status) { should eq 0 }
 end
 

--- a/versions.config
+++ b/versions.config
@@ -8,9 +8,9 @@ RAW_IMAGE_VERSION="v0.2.2"
 RAW_IMAGE_CHECKSUM="fe9af7686960d5d2dd6c364197e196d751f6adedd7da515ed6521c31e9582f8a"
 
 # specific versions of kernel/firmware and docker tools
-# export KERNEL_VERSION="107-1"
-export DOCKER_DEB_URL="https://github.com/DieterReuter/docker-armbuilds/releases/download/v1.13.1/docker-engine_1.13.1-0.debian-jessie_arm64.deb"
-export DOCKER_DEB_CHECKSUM="dd7875ee1f62a9784c96cf22cd3dedbe61704ac5c2e054d6cfc914ac0e48de77"
+export KERNEL_VERSION="108-1"
+export DOCKER_DEB_URL="https://github.com/docbobo/docker/releases/download/v17.03.0-ce/docker-engine_17.03.0.ce-0.debian-jessie_arm64.deb"
+export DOCKER_DEB_CHECKSUM="7de1a102015122c592d196d0936e8580f7ff591ef2ad93857370f33874dea1ed"
 export DOCKER_COMPOSE_VERSION="1.9.0-23"
 export DOCKER_MACHINE_VERSION="0.9.0-39"
 export DEVICE_INIT_VERSION="0.1.8"


### PR DESCRIPTION
The official jessie build of docker on aarch64 will probably require ```seccomp```. This is available via ```jessie-backports``` and is installed along with docker ```17.03.0-ce```.

@StefanScherer no need to create a release right away.